### PR TITLE
画面中央の名前を"wake"に変更

### DIFF
--- a/lib/presentation/gemini_app.dart
+++ b/lib/presentation/gemini_app.dart
@@ -8,7 +8,7 @@ class GeminiApp extends StatelessWidget {
     return const MaterialApp(
       home: Scaffold(
         body: Center(
-          child: Text("Aoi"),
+          child: Text("wake"),
         ),
       ),
     );


### PR DESCRIPTION
## 作業内容
画面中央の名前を"wake"に変更

## スクショ
### 変更前
<img src="https://github.com/user-attachments/assets/ef94bc0b-2163-4fe5-9a76-8b3c82fa71fd" alt="Screenshot_20240805_103648" width="300" />

### 変更後
<img src="https://github.com/user-attachments/assets/f3ec9d1a-a4a1-4cfa-8ee6-7905b696bb47" alt="Screenshot_20240805_103119" width="300" />

## Issue
[初期設定 & プルリクエスト練習 for わけ #3](https://github.com/project-gemini-by-fluttter-univ/gemini-app/issues/3)